### PR TITLE
onnx分支C++对比项目升级1.5.1

### DIFF
--- a/cpp_projects/OcrLiteNcnn/README.md
+++ b/cpp_projects/OcrLiteNcnn/README.md
@@ -1,14 +1,16 @@
 # OcrLiteNcnn
 
 ### Project下载
+
 * 有整合好源码和依赖库的完整工程项目，文件比较大，可到Q群共享内下载，找以Project开头的压缩包文件
 * 如果想自己折腾，则请继续阅读本说明
 
 ### Demo下载(win、mac、linux)
-编译好的demo文件可以到Q群共享内下载
-或者[Gitee下载](https://gitee.com/benjaminwan/ocr-lite-ncnn/releases)
+
+编译好的demo文件可以到Q群共享内下载 或者[Gitee下载](https://gitee.com/benjaminwan/ocr-lite-ncnn/releases)
 
 ### 介绍
+
 ChineseOcr Lite Ncnn，超轻量级中文OCR PC Demo，支持ncnn推理
 
 **对应chineseocr lite的onnx分支**
@@ -20,8 +22,10 @@ ChineseOcr Lite Ncnn，超轻量级中文OCR PC Demo，支持ncnn推理
 采用ncnn神经网络前向计算框架[https://github.com/Tencent/ncnn](https://github.com/Tencent/ncnn)
 
 ### 模型下载
+
 [模型下载地址](https://github.com/ouyanghuiyu/chineseocr_lite/tree/onnx/models_ncnn)
 下载后解压到项目根目录
+
 ```
 OcrLiteNcnn/models
     ├── angle_op.bin
@@ -34,12 +38,16 @@ OcrLiteNcnn/models
 ```
 
 ### 依赖的第三方库下载
+
 1. 下载opencv和ncnn，[下载地址](https://gitee.com/benjaminwan/ocr-lite-ncnn/releases/v1.0)
+
 * OpenCv动态库：opencv-(版本号)-sharedLib.7z
 * OpenCv静态库：opencv-(版本号)-staticLib.7z
 * ncnn静态库含vulkan：ncnn-(版本号)-vulkan-staticLib.7z
 * ncnn静态库：ncnn-(版本号)-staticLib.7z
 * 把压缩包解压到项目根目录，解压后目录结构
+* 注意：ncnn v20210124开始，支持lstm。本demo从v1.5.1开始，crnn改用lstm，请注意选择ncnn版本。
+
 ```
 OcrLiteNcnn
     ├── ncnn-static
@@ -47,31 +55,39 @@ OcrLiteNcnn
     ├── opencv-shared
     ├── opencv-static
 ```
+
 2. Vulkan SDK，[下载地址](https://vulkan.lunarg.com/sdk/home)
+
 * 如果想编译ncnn带vulkan支持的版本，则必须先安装Vulkan SDK。
 * 一般下载最新版即可，当前最新版1.2.162.0
 * Windows：直接双击安装。
 * macOS：加载dmg后，终端执行```./install_vulkan.py```
-* Linux: 解压tar.gz文件后，把scripts文件夹里的install-vulkan-linux.sh复制到解压后的文件夹，并打开终端执行 
+* Linux: 解压tar.gz文件后，把scripts文件夹里的install-vulkan-linux.sh复制到解压后的文件夹，并打开终端执行
+
 ```
 chmod a+x install-vulkan-linux.sh
 ./install-vulkan-linux.sh
 ```
 
 ### 编译环境
+
 1. Windows 10 x64
 2. macOS 10.15
 3. Linux Ubuntu 1604 x64
+
 **注意：以下说明仅适用于本机编译。如果需要交叉编译为arm等其它平台(参考android)，则需要先交叉编译所有第三方依赖库(ncnn、opencv)，然后再把依赖库整合替换到本项目里。**
 
 ### Windows编译说明
+
 #### Windows nmake编译
+
 1. 安装VS2017或VS2019，安装时，至少选中'使用C++的桌面开发'
 2. cmake请自行下载&配置，[下载地址](https://cmake.org/download/)
 3. 开始菜单打开"x64 Native Tools Command Prompt for VS 2019"或"适用于 VS2017 的 x64 本机工具"，并转到本项目根目录
 4. 运行```build.bat```并按照提示输入选项，最后选择'编译成可执行文件'
 5. 编译完成后运行```run-test.bat```进行测试(注意修改脚本内的目标图片路径)
 6. 编译JNI动态运行库(可选，可用于java调用)
+
 * 下载jdk-8u221-windows-x64.exe，安装选项默认(确保“源代码”项选中)，安装完成后，打开“系统”属性->高级->环境变量
 * 新建“系统变量”，变量名```JAVA_HOME``` ，变量值```C:\Program Files\Java\jdk1.8.0_221``
 * 新建“系统变量”，变量名```CLASSPATH``` ，变量值```.;%JAVA_HOME%\lib\dt.jar;%JAVA_HOME%\lib\tools.jar;``
@@ -80,77 +96,72 @@ chmod a+x install-vulkan-linux.sh
 * 运行```build.bat```并按照提示输入选项，最后选择'编译成JNI动态库'
 
 #### Windows Visual Studio编译说明
+
 1. VS2017/VS2019，cmake……等安装配置参考上述步骤。
 2. 运行generate-vs-project.bat，输入数字选择要生成的visual studio项目解决方案版本。
 3. 根据你的编译环境，进入build-xxxx-x86或x64文件夹，打开OcrLiteNcnn.sln。
 4. 在顶部工具栏选择Release，在右边的"解决方案"窗口，右键选中"ALL_BUILD"->生成。要选择Debug，则您必须自行编译Debug版的opencv或ncnn。
 
 #### Windows部署说明
+
 1. 编译选项选择第三方库为动态库时，部署的时候记得把dll复制到可执行文件目录。
 2. 部署时如果提示缺少"VCRUNTIME140_1.dll"，下载安装适用于 Visual Studio 2015、2017 和 2019 的 Microsoft Visual C++ 可再发行软件包，
    [下载地址](https://support.microsoft.com/zh-cn/help/2977003/the-latest-supported-visual-c-downloads)
 
 ### Mac编译说明
+
 1. macOS Catalina 10.15.x，安装Xcode 12.1，并安装Xcode Command Line Tools, 终端运行```xcode-select –install```
 2. 自行下载安装HomeBrew，cmake >=3.1[下载地址](https://cmake.org/download/)
 3. libomp: ```brew install libomp```
 4. 终端打开项目根目录，```./build.sh```并按照提示输入选项，最后选择'编译成可执行文件'
 5. 测试：```./run-test.sh```(注意修改脚本内的目标图片路径)
 6. 编译JNI动态运行库(可选，可用于java调用)
+
 * 下载jdk-8u221-macosx-x64.dmg，安装。
 * 编辑用户目录下的隐藏文件```.zshrc``` ，添加```export JAVA_HOME=$(/usr/libexec/java_home)```
 * 运行```build.sh```并按照提示输入选项，最后选择'编译成JNI动态库'
 
 #### macOS部署说明
+
 opencv或onnxruntime使用动态库时，参考下列方法：
+
 * 把动态库所在路径加入DYLD_LIBRARY_PATH搜索路径
 * 把动态库复制或链接到到/usr/lib
 
 ### Linux编译说明
+
 1. Ubuntu16.04 LTS 或其它发行版
 2. ```sudo apt-get install build-essential```
 3. g++>=5，cmake>=3.1[下载地址](https://cmake.org/download/)
 4. 终端打开项目根目录，```./build.sh```并按照提示输入选项，最后选择'编译成可执行文件'
 5. 测试：```./run-test.sh```(注意修改脚本内的目标图片路径)
 6. 编译JNI动态运行库(可选，可用于java调用)
+
 * 下载jdk-8u221并安装配置
 * 运行```build.sh```并按照提示输入选项，最后选择'编译成JNI动态库'
 * **注意：编译JNI时，g++版本要求>=6**
 
 #### Linux部署说明
+
 opencv或onnxruntime使用动态库时，参考下列方法：
+
 * 把动态库所在路径加入LD_LIBRARY_PATH搜索路径
 * 把动态库复制或链接到到/usr/lib
 
 ### 编译参数说明
+
 build.sh编译参数
+
 1. ```OCR_OPENMP=ON```：启用(ON)或禁用(OFF) AngleNet和CrnnNet阶段使用OpenMP并行运算。
-* 测试硬件：NUC8I7HVK冥王峡谷(i7-8809G) 32GRAM 2TSSD
-* 测试条件：不计算模型加载、框架初始化、加载图片的时间，线程数设置为当前CPU逻辑核心数量，跑100次计算平均耗时。
-* 经过测试，dbNet阶段使用OpenMP不能减少耗时
-* 所以此选项仅影响angelNet和crnnNet阶段的代码
-* 因为ncnn的crnn阶段因算子不支持而采用了外循环，所以在外循环使用OpenMP后，效果显著
-* 为了对比测试，选取了一张640x640的普通图片和一张分辨率为810*12119长图进行测试。
-* 第一个表格为普通图的测试结果，第二个图为长图的测试结果
-* 结论：启用OpenMP能快10%~30%(取决于图片文字数量)
-
-| 平台    | 系统版本  | 单线程 | OpenMP | 耗时倍率 |
-| ------- | ------- | ----: | ----: | ----: |
-| macOS   | 10.15.7 | 254ms | 227ms | 1.12 |
-| Windows | 10 x64  | 334ms | 308ms | 1.08 |
-
-| 平台    | 系统版本  | 单线程 | OpenMP | 耗时倍率 |
-| ------- | ------- | ----: | ----: | ----: |
-| macOS   | 10.15.7 | 8427ms | 6055ms | 1.39 |
-| Windows | 10 x64  | 12379ms | 9621ms | 1.28 |
-
 2. ```OCR_LIB=ON```： 启用(ON)或禁用(OFF) ON时编译为jni lib，OFF时编译为可执行文件
 3. ```OCR_STATIC=ON```： 启用(ON)或禁用(OFF) ON时选择opencv静态库进行编译，OFF时则选择动态库编译
 4. ```OCR_VULKAN=ON```： 启用(ON)或禁用(OFF) ON时选择ncnn(带vulkan)静态库进行编译，OFF时则选择不带vulkan的版本编译
 
 ### 输入参数说明
+
 * 请参考main.h中的命令行参数说明。
 * 每个参数有一个短参数名和一个长参数名，用短的或长的均可。
+
 1. ```-d或--models```：模型所在文件夹路径，可以相对路径也可以绝对路径。
 2. ```-1或--det```:dbNet模型文件名(不含扩展名)
 3. ```-2或--cls```:angleNet模型文件名(不含扩展名)
@@ -159,7 +170,8 @@ build.sh编译参数
 6. ```-i或--image```：目标图片路径，可以相对路径也可以绝对路径。
 7. ```-t或--numThread```：线程数量。
 8. ```-p或--padding```：图像预处理，在图片外周添加白边，用于提升识别率，文字框没有正确框住所有文字时，增加此值。
-9. ```-s或--maxSideLen```：按图片最长边的长度，此值为0代表不缩放，例：1024，如果图片长边大于1024则把图像整体缩小到1024再进行图像分割计算，如果图片长边小于1024则不缩放，如果图片长边小于32，则缩放到32。
+9. ```-s或--maxSideLen```
+   ：按图片最长边的长度，此值为0代表不缩放，例：1024，如果图片长边大于1024则把图像整体缩小到1024再进行图像分割计算，如果图片长边小于1024则不缩放，如果图片长边小于32，则缩放到32。
 10. ```-b或--boxScoreThresh```：文字框置信度门限，文字框没有正确框住所有文字时，减小此值。
 11. ```-o或--boxThresh```：请自行试验。
 12. ```-u或--unClipRatio```：单个文字框大小倍率，越大时单个文字框越大。此项与图片的大小相关，越大的图片此值应该越大。
@@ -168,11 +180,12 @@ build.sh编译参数
 15. ```-h或--help```：打印命令行帮助。
 16. ```-G或--GPU```：尝试使用gpu进行计算，-1(使用CPU)/0(使用GPU0)/1(使用GPU1)/...，GPU选择失败时，则使用CPU进行计算。
 
-
 ### 编译脚本说明
+
 * scripts文件夹内有一些脚本，用于自行编译ncnn，另有编译opencv的脚本，请到OcrLiteOnnx项目内寻找。
 
 ### 关于内存泄漏与valgrind
+
 * 项目根目录的valgrind-memcheck.sh用来检查内存泄漏(需要debug编译)。
 * valgrind-memcheck.txt是demo在linux平台的检查报告。
 * 报告中的"possibly lost"均发生在第三方库，possibly lost可能不一定是泄露，暂时不管。

--- a/cpp_projects/OcrLiteNcnn/build.bat
+++ b/cpp_projects/OcrLiteNcnn/build.bat
@@ -7,11 +7,12 @@ echo.
 
 echo "========编译选项========"
 echo "请注意：项目默认使用Release库，除非您自行编译Debug版的ncnn和Opencv，否则请不要选择Debug编译"
-echo "请输入编译选项并回车: 1)Release, 2)Debug"
+echo "请输入编译选项并回车: 1)Release, 2)Debug, 3)预设"
 set BUILD_TYPE=Release
 set /p flag=
 if %flag% == 1 (set BUILD_TYPE=Release)^
 else if %flag% == 2 (set BUILD_TYPE=Debug)^
+else if %flag% == 3 (goto :makeAllExe)^
 else (echo 输入错误！Input Error!)
 echo.
 
@@ -49,6 +50,7 @@ if %flag% == 1 (set BUILD_LIB=OFF)^
 else if %flag% == 2 (set BUILD_LIB=ON)^
 else (echo 输入错误！Input Error!)
 echo.
+
 if %BUILD_LIB% == OFF (call :makeExe)^
 else (call :makeLib)
 echo cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DOCR_OPENMP=%BUILD_OPENMP% -DOCR_LIB=%BUILD_LIB% -DOCR_STATIC=%BUILD_STATIC% -DOCR_VULKAN=%BUILD_NCNN_VULKAN% ..
@@ -66,5 +68,30 @@ GOTO:EOF
 mkdir build-lib
 pushd build-lib
 GOTO:EOF
+
+:makeAllExe
+mkdir win-cpu-%VSCMD_ARG_TGT_ARCH%
+pushd win-cpu-%VSCMD_ARG_TGT_ARCH%
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=OFF -DOCR_STATIC=ON -DOCR_VULKAN=OFF ..
+nmake
+popd
+
+mkdir win-gpu-%VSCMD_ARG_TGT_ARCH%
+pushd win-gpu-%VSCMD_ARG_TGT_ARCH%
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=OFF -DOCR_STATIC=ON -DOCR_VULKAN=ON ..
+nmake
+popd
+
+mkdir win-lib-cpu-%VSCMD_ARG_TGT_ARCH%
+pushd win-lib-cpu-%VSCMD_ARG_TGT_ARCH%
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=ON -DOCR_STATIC=ON -DOCR_VULKAN=OFF ..
+nmake
+popd
+
+mkdir win-lib-gpu-%VSCMD_ARG_TGT_ARCH%
+pushd win-lib-gpu-%VSCMD_ARG_TGT_ARCH%
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=ON -DOCR_STATIC=ON -DOCR_VULKAN=ON ..
+nmake
+popd
 
 @ENDLOCAL

--- a/cpp_projects/OcrLiteNcnn/build.sh
+++ b/cpp_projects/OcrLiteNcnn/build.sh
@@ -1,15 +1,56 @@
 #!/usr/bin/env bash
 
+function buildAll() {
+  mkdir -p ${sysOS}-CPU
+  pushd ${sysOS}-CPU
+  cmake -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=OFF -DOCR_STATIC=ON -DOCR_VULKAN=OFF ..
+  make -j $NUM_THREADS
+  popd
+
+  mkdir -p ${sysOS}-GPU
+  pushd ${sysOS}-GPU
+  cmake -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=OFF -DOCR_STATIC=ON -DOCR_VULKAN=ON ..
+  make -j $NUM_THREADS
+  popd
+
+  mkdir -p ${sysOS}-Lib-CPU
+  pushd ${sysOS}-Lib-CPU
+  cmake -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=ON -DOCR_STATIC=ON -DOCR_VULKAN=OFF ..
+  make -j $NUM_THREADS
+  popd
+
+  mkdir -p ${sysOS}-Lib-GPU
+  pushd ${sysOS}-Lib-GPU
+  cmake -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=ON -DOCR_STATIC=ON -DOCR_VULKAN=ON ..
+  make -j $NUM_THREADS
+  popd
+}
+
+sysOS=$(uname -s)
+NUM_THREADS=1
+if [ $sysOS == "Darwin" ]; then
+  #echo "I'm MacOS"
+  NUM_THREADS=$(sysctl -n hw.ncpu)
+elif [ $sysOS == "Linux" ]; then
+  #echo "I'm Linux"
+  NUM_THREADS=$(grep ^processor /proc/cpuinfo | wc -l)
+else
+  echo "Other OS: $sysOS"
+fi
+
 echo "========请先参考README.md准备好编译环境========"
 echo
 
 echo "========编译选项========"
-echo "请输入编译选项并回车: 1)Release, 2)Debug"
+echo "请输入编译选项并回车: 1)Release, 2)Debug, 3)预设"
 read -p "" BUILD_TYPE
 if [ $BUILD_TYPE == 1 ]; then
-    BUILD_TYPE=Release
+  BUILD_TYPE=Release
 elif [ $BUILD_TYPE == 2 ]; then
-    BUILD_TYPE=Debug
+  BUILD_TYPE=Debug
+elif [ $BUILD_TYPE == 3 ]; then
+  buildAll
+  exit
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -17,9 +58,9 @@ fi
 echo "请输入OpenMP选项并回车: 1)启用OpenMP(Angle阶段和Crnn阶段多线程并行执行), 2)禁用OpenMP(Angle阶段和Crnn阶段单线程执行)"
 read -p "" BUILD_OPENMP
 if [ $BUILD_OPENMP == 1 ]; then
-    BUILD_OPENMP=ON
+  BUILD_OPENMP=ON
 elif [ $BUILD_OPENMP == 2 ]; then
-    BUILD_OPENMP=OFF
+  BUILD_OPENMP=OFF
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -29,9 +70,9 @@ echo "使用动态库时，编译出来的可执行文件较小，但Linux部署
 echo "请选择要使用的Opencv库选项并回车: 1)Static静态库，2)Shared动态库"
 read -p "" BUILD_STATIC
 if [ $BUILD_STATIC == 1 ]; then
-    BUILD_STATIC=ON
+  BUILD_STATIC=ON
 elif [ $BUILD_STATIC == 2 ]; then
-    BUILD_STATIC=OFF
+  BUILD_STATIC=OFF
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -39,9 +80,9 @@ fi
 echo "请选择要使用的ncnn库选项并回车: 1)ncnn(CPU)，2)ncnn(vulkan)"
 read -p "" BUILD_VULKAN
 if [ $BUILD_VULKAN == 1 ]; then
-    BUILD_VULKAN=OFF
+  BUILD_VULKAN=OFF
 elif [ $BUILD_VULKAN == 2 ]; then
-    BUILD_VULKAN=ON
+  BUILD_VULKAN=ON
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -50,31 +91,19 @@ echo "请注意：如果选择2)编译为JNI动态库时，必须安装配置Ora
 echo "请选择编译输出类型并回车: 1)编译成可执行文件，2)编译成JNI动态库"
 read -p "" BUILD_LIB
 if [ $BUILD_LIB == 1 ]; then
-    BUILD_LIB=OFF
+  BUILD_LIB=OFF
 elif [ $BUILD_LIB == 2 ]; then
-    BUILD_LIB=ON
+  BUILD_LIB=ON
 else
   echo -e "输入错误！Input Error!"
 fi
 
 if [ $BUILD_LIB == OFF ]; then
-    mkdir -p build
-    pushd build
+  mkdir -p build
+  pushd build
 else
-    mkdir -p build-lib
-    pushd build-lib
-fi
-
-sysOS=`uname -s`
-NUM_THREADS=1
-if [ $sysOS == "Darwin" ];then
-    #echo "I'm MacOS"
-    NUM_THREADS=$(sysctl -n hw.ncpu)
-elif [ $sysOS == "Linux" ];then
-    #echo "I'm Linux"
-    NUM_THREADS=$(grep ^processor /proc/cpuinfo | wc -l)
-else
-    echo "Other OS: $sysOS"
+  mkdir -p build-lib
+  pushd build-lib
 fi
 
 echo "cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DOCR_OPENMP=${BUILD_OPENMP} -DOCR_LIB=${BUILD_LIB} -DOCR_STATIC=${BUILD_STATIC} -DOCR_VULKAN=${BUILD_VULKAN} .."

--- a/cpp_projects/OcrLiteNcnn/include/version.h
+++ b/cpp_projects/OcrLiteNcnn/include/version.h
@@ -1,6 +1,6 @@
 #ifndef __OCR_VERSION_H__
 #define __OCR_VERSION_H__
 
-#define VERSION "1.5.0.20210115"
+#define VERSION "1.5.1.20210128"
 
 #endif //__OCR_VERSION_H__

--- a/cpp_projects/OcrLiteNcnn/src/CrnnNet.cpp
+++ b/cpp_projects/OcrLiteNcnn/src/CrnnNet.cpp
@@ -44,7 +44,7 @@ bool CrnnNet::initModel(const std::string &pathStr, const std::string &keysPath)
     }
     if (keys.size() != 5531) {
         fprintf(stderr, "missing keys\n");
-		return false;
+        return false;
     }
     printf("total keys size(%lu)\n", keys.size());
     return true;
@@ -104,8 +104,8 @@ TextLine CrnnNet::getTextLine(const cv::Mat &src) {
     ncnn::Mat out;
     extractor.extract("out", out);
 
-	float *floatArray = (float *) out.data;
-	std::vector<float> outputData(floatArray, floatArray + out.h * out.w);
+    float *floatArray = (float *) out.data;
+    std::vector<float> outputData(floatArray, floatArray + out.h * out.w);
     return scoreToTextLine(outputData, out.h, out.w);
 }
 

--- a/cpp_projects/OcrLiteNcnn/src/OcrUtils.cpp
+++ b/cpp_projects/OcrLiteNcnn/src/OcrUtils.cpp
@@ -343,12 +343,6 @@ void printGpuInfo() {
     auto gpuCount = ncnn::get_gpu_count();
     if (gpuCount != 0) {
         printf("This device has %d GPUs\n", gpuCount);
-        for (int i = 0; i < gpuCount; ++i) {
-            ncnn::GpuInfo gpuInfo = ncnn::get_gpu_info(i);
-            auto computeQueueCount = gpuInfo.compute_queue_count;
-            printf("GPU(%d) name(%s) queueCount(%u) vid(0x%x) pid(0x%x)\n", i, gpuInfo.device_name.c_str(),
-                   computeQueueCount, gpuInfo.vendor_id, gpuInfo.device_id);
-        }
     } else {
         printf("This device does not have a GPU\n");
     }

--- a/cpp_projects/OcrLiteOnnx/README.md
+++ b/cpp_projects/OcrLiteOnnx/README.md
@@ -1,14 +1,16 @@
 # OcrLiteOnnx
 
 ### Project下载
+
 * 有整合好源码和依赖库的完整工程项目，文件比较大，可到Q群共享内下载，找以Project开头的压缩包文件
 * 如果想自己折腾，则请继续阅读本说明
 
 ### Demo下载(win、mac、linux)
-编译好的demo文件可以到Q群共享内下载
-或者[Gitee下载](https://gitee.com/benjaminwan/ocr-lite-onnx/releases)
+
+编译好的demo文件可以到Q群共享内下载 或者[Gitee下载](https://gitee.com/benjaminwan/ocr-lite-onnx/releases)
 
 ### 介绍
+
 ChineseOcr Lite Onnx，超轻量级中文OCR PC Demo，支持onnxruntime推理
 
 **对应chineseocr lite的onnx分支**
@@ -20,8 +22,10 @@ ChineseOcr Lite Onnx，超轻量级中文OCR PC Demo，支持onnxruntime推理
 采用onnxruntime框架[https://github.com/microsoft/onnxruntime](https://github.com/microsoft/onnxruntime)
 
 ### 模型下载
+
 [模型下载地址](https://github.com/ouyanghuiyu/chineseocr_lite/tree/onnx/models)
 下载后解压到项目根目录
+
 ```
 OcrLiteOnnx/models
     ├── angle_net.onnx
@@ -31,13 +35,16 @@ OcrLiteOnnx/models
 ```
 
 ### 依赖的第三方库下载
+
 下载opencv和onnxruntime，[下载地址](https://gitee.com/benjaminwan/ocr-lite-onnx/releases/v1.0)
+
 * OpenCv动态库：opencv-(版本号)-sharedLib.7z
 * OpenCv静态库：opencv-(版本号)-staticLib.7z
 * OnnxRuntime动态库：onnxruntime-(版本号)-sharedLib.7z
 * OnnxRuntime静态库：onnxruntime-(版本号)-staticLib.7z
 * 可以选择只下载两者的动态库或两者的静态库(要么都是静态库要么都是动态库)，或者4种全部下载
 * 把压缩包解压到项目根目录，解压后目录结构
+
 ```
 OcrLiteOnnx
     ├── onnxruntime-shared
@@ -47,19 +54,24 @@ OcrLiteOnnx
 ```
 
 ### 编译环境
+
 1. Windows 10 x64
 2. macOS 10.15
 3. Linux Ubuntu 1604 x64
+
 **注意：以下说明仅适用于本机编译。如果需要交叉编译为arm等其它平台(参考android)，则需要先交叉编译所有第三方依赖库(onnxruntime、opencv)，然后再把依赖库整合替换到本项目里。**
 
 ### Windows编译说明
+
 #### Windows nmake编译
+
 1. 安装VS2017或VS2019，安装时，至少选中'使用C++的桌面开发'
 2. cmake请自行下载&配置，[下载地址](https://cmake.org/download/)
 3. 开始菜单打开"x64 Native Tools Command Prompt for VS 2019"或"适用于 VS2017 的 x64 本机工具"，并转到本项目根目录
 4. 运行```build.bat```并按照提示输入选项，最后选择'编译成可执行文件'
 5. 编译完成后运行```run-test.bat```进行测试(注意修改脚本内的目标图片路径)
 6. 编译JNI动态运行库(可选，可用于java调用)
+
 * 下载jdk-8u221-windows-x64.exe，安装选项默认(确保“源代码”项选中)，安装完成后，打开“系统”属性->高级->环境变量
 * 新建“系统变量”，变量名```JAVA_HOME``` ，变量值```C:\Program Files\Java\jdk1.8.0_221``
 * 新建“系统变量”，变量名```CLASSPATH``` ，变量值```.;%JAVA_HOME%\lib\dt.jar;%JAVA_HOME%\lib\tools.jar;``
@@ -68,56 +80,70 @@ OcrLiteOnnx
 * 运行```build.bat```并按照提示输入选项，最后选择'编译成JNI动态库'
 
 #### Windows Visual Studio编译说明
+
 1. VS2017/VS2019，cmake……等安装配置参考上述步骤。
 2. 运行generate-vs-project.bat，输入数字选择要生成的visual studio项目解决方案版本。
 3. 根据你的编译环境，进入build-xxxx-x86或x64文件夹，打开OcrLiteOnnx.sln。
 4. 在顶部工具栏选择Release，在右边的"解决方案"窗口，右键选中"ALL_BUILD"->生成。要选择Debug，则您必须自行编译Debug版的opencv或onnxruntime。
 
 #### Windows部署说明
+
 1. 编译选项选择第三方库为动态库时，部署的时候记得把dll复制到可执行文件目录。
 2. 部署时如果提示缺少"VCRUNTIME140_1.dll"，下载安装适用于 Visual Studio 2015、2017 和 2019 的 Microsoft Visual C++ 可再发行软件包，
    [下载地址](https://support.microsoft.com/zh-cn/help/2977003/the-latest-supported-visual-c-downloads)
 
 ### Mac编译说明
+
 1. macOS Catalina 10.15.x，安装Xcode 12.1，并安装Xcode Command Line Tools, 终端运行```xcode-select –install```
 2. 自行下载安装HomeBrew，cmake >=3.1[下载地址](https://cmake.org/download/)
 3. libomp: ```brew install libomp```
 4. 终端打开项目根目录，```./build.sh```并按照提示输入选项，最后选择'编译成可执行文件'
 5. 测试：```./run-test.sh```(注意修改脚本内的目标图片路径)
 6. 编译JNI动态运行库(可选，可用于java调用)
+
 * 下载jdk-8u221-macosx-x64.dmg，安装。
 * 编辑用户目录下的隐藏文件```.zshrc``` ，添加```export JAVA_HOME=$(/usr/libexec/java_home)```
 * 运行```build.sh```并按照提示输入选项，最后选择'编译成JNI动态库'
 
 #### macOS部署说明
+
 opencv或onnxruntime使用动态库时，参考下列方法：
+
 * 把动态库所在路径加入DYLD_LIBRARY_PATH搜索路径
 * 把动态库复制或链接到到/usr/lib
 
 ### Linux编译说明
+
 1. Ubuntu16.04 LTS 或其它发行版
 2. ```sudo apt-get install build-essential```
 3. g++>=5，cmake>=3.1[下载地址](https://cmake.org/download/)
 4. 终端打开项目根目录，```./build.sh```并按照提示输入选项，最后选择'编译成可执行文件'
 5. 测试：```./run-test.sh```(注意修改脚本内的目标图片路径)
 6. 编译JNI动态运行库(可选，可用于java调用)
+
 * 下载jdk-8u221并安装配置
 * 运行```build.sh```并按照提示输入选项，最后选择'编译成JNI动态库'
 
 #### Linux部署说明
+
 opencv或onnxruntime使用动态库时，参考下列方法：
+
 * 把动态库所在路径加入LD_LIBRARY_PATH搜索路径
 * 把动态库复制或链接到到/usr/lib
 
 ### 编译参数说明
+
 build.sh编译参数：
+
 1. ```OCR_OPENMP=ON```：启用(ON)或禁用(OFF) ON时AngleNet和CrnnNet阶段使用OpenMP并行运算，OFF时单线程运算
 2. ```OCR_LIB=ON```： 启用(ON)或禁用(OFF) ON时编译为jni lib，OFF时编译为可执行文件
 3. ```OCR_STATIC=ON```： 启用(ON)或禁用(OFF) ON时选择opencv和onnxruntime的静态库进行编译，OFF时则选择动态库编译
 
 ### 输入参数说明
+
 * 请参考main.h中的命令行参数说明。
 * 每个参数有一个短参数名和一个长参数名，用短的或长的均可。
+
 1. ```-d或--models```：模型所在文件夹路径，可以相对路径也可以绝对路径。
 2. ```-1或--det```:dbNet模型文件名(含扩展名)
 3. ```-2或--cls```:angleNet模型文件名(含扩展名)
@@ -126,7 +152,8 @@ build.sh编译参数：
 6. ```-i或--image```：目标图片路径，可以相对路径也可以绝对路径。
 7. ```-t或--numThread```：线程数量。
 8. ```-p或--padding```：图像预处理，在图片外周添加白边，用于提升识别率，文字框没有正确框住所有文字时，增加此值。
-9. ```-s或--maxSideLen```：按图片最长边的长度，此值为0代表不缩放，例：1024，如果图片长边大于1024则把图像整体缩小到1024再进行图像分割计算，如果图片长边小于1024则不缩放，如果图片长边小于32，则缩放到32。
+9. ```-s或--maxSideLen```
+   ：按图片最长边的长度，此值为0代表不缩放，例：1024，如果图片长边大于1024则把图像整体缩小到1024再进行图像分割计算，如果图片长边小于1024则不缩放，如果图片长边小于32，则缩放到32。
 10. ```-b或--boxScoreThresh```：文字框置信度门限，文字框没有正确框住所有文字时，减小此值。
 11. ```-o或--boxThresh```：请自行试验。
 12. ```-u或--unClipRatio```：单个文字框大小倍率，越大时单个文字框越大。此项与图片的大小相关，越大的图片此值应该越大。
@@ -135,9 +162,11 @@ build.sh编译参数：
 15. ```-h或--help```：打印命令行帮助。
 
 ### 编译脚本说明
+
 * scripts文件夹内有一些脚本，用于自行编译opencv和onnxruntime。
 
 ### 关于内存泄漏与valgrind
+
 * 项目根目录的valgrind-memcheck.sh用来检查内存泄漏(需要debug编译)。
 * valgrind-memcheck.txt是demo在linux平台的检查报告。
 * 报告中的"possibly lost"均发生在第三方库，possibly lost可能不一定是泄露，暂时不管。

--- a/cpp_projects/OcrLiteOnnx/build.bat
+++ b/cpp_projects/OcrLiteOnnx/build.bat
@@ -7,11 +7,12 @@ echo.
 
 echo "========编译选项========"
 echo "请注意：项目默认使用Release库，除非您自行编译Debug版的Onnxruntime和Opencv，否则请不要选择Debug编译"
-echo "请输入编译选项并回车: 1)Release, 2)Debug"
+echo "请输入编译选项并回车: 1)Release, 2)Debug, 3)预设"
 set BUILD_TYPE=Release
 set /p flag=
 if %flag% == 1 (set BUILD_TYPE=Release)^
 else if %flag% == 2 (set BUILD_TYPE=Debug)^
+else if %flag% == 3 (goto :makeAllExe)^
 else (echo 输入错误！Input Error!)
 echo.
 
@@ -58,5 +59,18 @@ GOTO:EOF
 mkdir build-lib
 pushd build-lib
 GOTO:EOF
+
+:makeAllExe
+mkdir win-%VSCMD_ARG_TGT_ARCH%
+pushd win-%VSCMD_ARG_TGT_ARCH%
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=OFF -DOCR_STATIC=ON ..
+nmake
+popd
+
+mkdir win-lib-%VSCMD_ARG_TGT_ARCH%
+pushd win-lib-%VSCMD_ARG_TGT_ARCH%
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=ON -DOCR_STATIC=ON ..
+nmake
+popd
 
 @ENDLOCAL

--- a/cpp_projects/OcrLiteOnnx/build.sh
+++ b/cpp_projects/OcrLiteOnnx/build.sh
@@ -1,15 +1,44 @@
 #!/usr/bin/env bash
 
+function buildAll() {
+  mkdir -p ${sysOS}
+  pushd ${sysOS}
+  cmake -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=OFF -DOCR_STATIC=ON ..
+  make -j $NUM_THREADS
+  popd
+
+  mkdir -p ${sysOS}-Lib
+  pushd ${sysOS}-Lib
+  cmake -DCMAKE_BUILD_TYPE=Release -DOCR_OPENMP=ON -DOCR_LIB=ON -DOCR_STATIC=ON ..
+  make -j $NUM_THREADS
+  popd
+}
+
+sysOS=$(uname -s)
+NUM_THREADS=1
+if [ $sysOS == "Darwin" ]; then
+  #echo "I'm MacOS"
+  NUM_THREADS=$(sysctl -n hw.ncpu)
+elif [ $sysOS == "Linux" ]; then
+  #echo "I'm Linux"
+  NUM_THREADS=$(grep ^processor /proc/cpuinfo | wc -l)
+else
+  echo "Other OS: $sysOS"
+fi
+
 echo "========请先参考README.md准备好编译环境========"
 echo
 
 echo "========编译选项========"
-echo "请输入编译选项并回车: 1)Release, 2)Debug"
+echo "请输入编译选项并回车: 1)Release, 2)Debug, 3)预设"
 read -p "" BUILD_TYPE
 if [ $BUILD_TYPE == 1 ]; then
-    BUILD_TYPE=Release
+  BUILD_TYPE=Release
 elif [ $BUILD_TYPE == 2 ]; then
-    BUILD_TYPE=Debug
+  BUILD_TYPE=Debug
+elif [ $BUILD_TYPE == 3 ]; then
+  buildAll
+  exit
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -17,9 +46,9 @@ fi
 echo "请输入OpenMP选项并回车: 1)启用OpenMP(Angle阶段和Crnn阶段多线程并行执行), 2)禁用OpenMP(Angle阶段和Crnn阶段单线程执行)"
 read -p "" BUILD_OPENMP
 if [ $BUILD_OPENMP == 1 ]; then
-    BUILD_OPENMP=ON
+  BUILD_OPENMP=ON
 elif [ $BUILD_OPENMP == 2 ]; then
-    BUILD_OPENMP=OFF
+  BUILD_OPENMP=OFF
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -29,9 +58,9 @@ echo "使用动态库时，编译出来的可执行文件较小，但Linux部署
 echo "请选择要使用的OnnxRuntime和Opencv库选项并回车: 1)Static静态库，2)Shared动态库"
 read -p "" BUILD_STATIC
 if [ $BUILD_STATIC == 1 ]; then
-    BUILD_STATIC=ON
+  BUILD_STATIC=ON
 elif [ $BUILD_STATIC == 2 ]; then
-    BUILD_STATIC=OFF
+  BUILD_STATIC=OFF
 else
   echo -e "输入错误！Input Error!"
 fi
@@ -40,31 +69,19 @@ echo "请注意：如果选择2)编译为JNI动态库时，必须安装配置Ora
 echo "请选择编译输出类型并回车: 1)编译成可执行文件，2)编译成JNI动态库"
 read -p "" BUILD_LIB
 if [ $BUILD_LIB == 1 ]; then
-    BUILD_LIB=OFF
+  BUILD_LIB=OFF
 elif [ $BUILD_LIB == 2 ]; then
-    BUILD_LIB=ON
+  BUILD_LIB=ON
 else
   echo -e "输入错误！Input Error!"
 fi
 
 if [ $BUILD_LIB == OFF ]; then
-    mkdir -p build
-    pushd build
+  mkdir -p build
+  pushd build
 else
-    mkdir -p build-lib
-    pushd build-lib
-fi
-
-sysOS=`uname -s`
-NUM_THREADS=1
-if [ $sysOS == "Darwin" ];then
-    #echo "I'm MacOS"
-    NUM_THREADS=$(sysctl -n hw.ncpu)
-elif [ $sysOS == "Linux" ];then
-    #echo "I'm Linux"
-    NUM_THREADS=$(grep ^processor /proc/cpuinfo | wc -l)
-else
-    echo "Other OS: $sysOS"
+  mkdir -p build-lib
+  pushd build-lib
 fi
 
 echo "cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DOCR_OPENMP=${BUILD_OPENMP} -DOCR_LIB=${BUILD_LIB} -DOCR_STATIC=${BUILD_STATIC} .."

--- a/cpp_projects/OcrLiteOnnx/include/AngleNet.h
+++ b/cpp_projects/OcrLiteOnnx/include/AngleNet.h
@@ -26,8 +26,8 @@ private:
     Ort::SessionOptions sessionOptions = Ort::SessionOptions();
     int numThread = 0;
 
-    std::vector<char *> inputNames;
-    std::vector<char *> outputNames;
+    char *inputName;
+    char *outputName;
 
     const float meanValues[3] = {127.5, 127.5, 127.5};
     const float normValues[3] = {1.0 / 127.5, 1.0 / 127.5, 1.0 / 127.5};

--- a/cpp_projects/OcrLiteOnnx/include/CrnnNet.h
+++ b/cpp_projects/OcrLiteOnnx/include/CrnnNet.h
@@ -25,8 +25,8 @@ private:
     Ort::SessionOptions sessionOptions = Ort::SessionOptions();
     int numThread = 0;
 
-    std::vector<char *> inputNames;
-    std::vector<char *> outputNames;
+    char *inputName;
+    char *outputName;
 
     const float meanValues[3] = {127.5, 127.5, 127.5};
     const float normValues[3] = {1.0 / 127.5, 1.0 / 127.5, 1.0 / 127.5};

--- a/cpp_projects/OcrLiteOnnx/include/DbNet.h
+++ b/cpp_projects/OcrLiteOnnx/include/DbNet.h
@@ -23,8 +23,8 @@ private:
     Ort::Env env = Ort::Env(ORT_LOGGING_LEVEL_ERROR, "DbNet");
     Ort::SessionOptions sessionOptions = Ort::SessionOptions();
     int numThread = 0;
-    std::vector<char *> inputNames;
-    std::vector<char *> outputNames;
+    char *inputName;
+    char *outputName;
 
     const float meanValues[3] = {0.485 * 255, 0.456 * 255, 0.406 * 255};
     const float normValues[3] = {1.0 / 0.229 / 255.0, 1.0 / 0.224 / 255.0, 1.0 / 0.225 / 255.0};

--- a/cpp_projects/OcrLiteOnnx/include/OcrUtils.h
+++ b/cpp_projects/OcrLiteOnnx/include/OcrUtils.h
@@ -36,6 +36,18 @@ inline bool isFileExists(const std::string &name) {
     return (stat(name.c_str(), &buffer) == 0);
 }
 
+#ifdef _WIN32
+#define my_strtol wcstol
+#define my_strrchr wcsrchr
+#define my_strcasecmp _wcsicmp
+#define my_strdup _strdup
+#else
+#define my_strtol strtol
+#define my_strrchr strrchr
+#define my_strcasecmp strcasecmp
+#define my_strdup strdup
+#endif
+
 std::wstring strToWstr(std::string str);
 
 ScaleParam getScaleParam(cv::Mat &src, const float scale);
@@ -73,6 +85,10 @@ std::vector<int> getAngleIndexes(std::vector<Angle> &angles);
 std::vector<char *> getInputNames(Ort::Session *session);
 
 std::vector<char *> getOutputNames(Ort::Session *session);
+
+void getInputName(Ort::Session *session, char *&inputName);
+
+void getOutputName(Ort::Session *session, char *&outputName);
 
 void saveImg(cv::Mat &img, const char *imgPath);
 

--- a/cpp_projects/OcrLiteOnnx/include/version.h
+++ b/cpp_projects/OcrLiteOnnx/include/version.h
@@ -1,6 +1,6 @@
 #ifndef __OCR_VERSION_H__
 #define __OCR_VERSION_H__
 
-#define VERSION "1.5.0.20210115"
+#define VERSION "1.5.1.20210128"
 
 #endif //__OCR_VERSION_H__

--- a/cpp_projects/OcrLiteOnnx/src/AngleNet.cpp
+++ b/cpp_projects/OcrLiteOnnx/src/AngleNet.cpp
@@ -6,12 +6,8 @@ AngleNet::AngleNet() {}
 
 AngleNet::~AngleNet() {
     delete session;
-    for (auto name : inputNames) {
-        free(name);
-    }
-    for (auto name : outputNames) {
-        free(name);
-    }
+    free(inputName);
+    free(outputName);
 }
 
 void AngleNet::setNumThread(int numOfThread) {
@@ -42,8 +38,8 @@ void AngleNet::initModel(const std::string &pathStr) {
 #else
     session = new Ort::Session(env, pathStr.c_str(), sessionOptions);
 #endif
-    inputNames = getInputNames(session);
-    outputNames = getOutputNames(session);
+    getInputName(session,inputName);
+    getOutputName(session,outputName);
 }
 
 Angle scoreToAngle(const std::vector<float> &outputData) {
@@ -72,8 +68,7 @@ Angle AngleNet::getAngle(cv::Mat &src) {
                                                              inputShape.size());
     assert(inputTensor.IsTensor());
 
-    auto outputTensor = session->Run(Ort::RunOptions{nullptr}, inputNames.data(), &inputTensor,
-                                     inputNames.size(), outputNames.data(), outputNames.size());
+    auto outputTensor = session->Run(Ort::RunOptions{nullptr}, &inputName, &inputTensor, 1, &outputName, 1);
 
     assert(outputTensor.size() == 1 && outputTensor.front().IsTensor());
 

--- a/cpp_projects/OcrLiteOnnx/src/CrnnNet.cpp
+++ b/cpp_projects/OcrLiteOnnx/src/CrnnNet.cpp
@@ -7,12 +7,8 @@ CrnnNet::CrnnNet() {}
 
 CrnnNet::~CrnnNet() {
     delete session;
-    for (auto name : inputNames) {
-        free(name);
-    }
-    for (auto name : outputNames) {
-        free(name);
-    }
+    free(inputName);
+    free(outputName);
 }
 
 void CrnnNet::setNumThread(int numOfThread) {
@@ -43,8 +39,8 @@ void CrnnNet::initModel(const std::string &pathStr, const std::string &keysPath)
 #else
     session = new Ort::Session(env, pathStr.c_str(), sessionOptions);
 #endif
-    inputNames = getInputNames(session);
-    outputNames = getOutputNames(session);
+    getInputName(session, inputName);
+    getOutputName(session, outputName);
 
     //load keys
     std::ifstream in(keysPath.c_str());
@@ -116,8 +112,7 @@ TextLine CrnnNet::getTextLine(const cv::Mat &src) {
                                                              inputShape.size());
     assert(inputTensor.IsTensor());
 
-    auto outputTensor = session->Run(Ort::RunOptions{nullptr}, inputNames.data(), &inputTensor,
-                                     inputNames.size(), outputNames.data(), outputNames.size());
+    auto outputTensor = session->Run(Ort::RunOptions{nullptr}, &inputName, &inputTensor, 1, &outputName, 1);
 
     assert(outputTensor.size() == 1 && outputTensor.front().IsTensor());
 

--- a/cpp_projects/OcrLiteOnnx/src/OcrUtils.cpp
+++ b/cpp_projects/OcrLiteOnnx/src/OcrUtils.cpp
@@ -385,6 +385,30 @@ std::vector<char *> getOutputNames(Ort::Session *session) {
     return outputNodeNames;
 }
 
+void getInputName(Ort::Session *session, char *&inputName) {
+    size_t numInputNodes = session->GetInputCount();
+    if (numInputNodes > 0) {
+        Ort::AllocatorWithDefaultOptions allocator;
+        {
+            char *t = session->GetInputName(0, allocator);
+            inputName = my_strdup(t);
+            allocator.Free(t);
+        }
+    }
+}
+
+void getOutputName(Ort::Session *session, char *&outputName) {
+    size_t numOutputNodes = session->GetInputCount();
+    if (numOutputNodes > 0) {
+        Ort::AllocatorWithDefaultOptions allocator;
+        {
+            char *t = session->GetOutputName(0, allocator);
+            outputName = my_strdup(t);
+            allocator.Free(t);
+        }
+    }
+}
+
 void saveImg(cv::Mat &img, const char *imgPath) {
     cv::imwrite(imgPath, img);
 }

--- a/cpp_projects/OcrLiteOnnx/valgrind-memcheck.txt
+++ b/cpp_projects/OcrLiteOnnx/valgrind-memcheck.txt
@@ -1,301 +1,301 @@
-==10966== Memcheck, a memory error detector
-==10966== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
-==10966== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
-==10966== Command: ./OcrLiteOnnx --models ../models --image ../../test_imgs/1.jpg --numThread 1 --padding 50 --imgResize 0 --boxScoreThresh 0.6 --boxThresh 0.3 --minArea 3 --unClipRatio 2.0 --doAngle 1 --mostAngle 1
-==10966== Parent PID: 10965
-==10966== 
-==10966== 
-==10966== HEAP SUMMARY:
-==10966==     in use at exit: 89,868 bytes in 130 blocks
-==10966==   total heap usage: 1,855,940 allocs, 1,855,810 frees, 225,393,411 bytes allocated
-==10966== 
-==10966== 80 bytes in 1 blocks are possibly lost in loss record 57 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4FA5F: cv::BmpDecoder::BmpDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4405A: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 80 bytes in 1 blocks are possibly lost in loss record 58 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C54230: cv::JpegDecoder::JpegDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44301: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 84 bytes in 1 blocks are possibly lost in loss record 59 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C52ECB: cv::HdrDecoder::HdrDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C441AF: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 84 bytes in 1 blocks are possibly lost in loss record 60 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C60769: cv::SunRasterDecoder::SunRasterDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C445A5: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 84 bytes in 1 blocks are possibly lost in loss record 61 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C501E5: cv::ExrDecoder::ExrDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4507E: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 88 bytes in 1 blocks are possibly lost in loss record 62 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C52EEF: cv::HdrDecoder::HdrDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C441AF: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 88 bytes in 1 blocks are possibly lost in loss record 63 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5BC30: cv::PngDecoder::PngDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44D9E: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 92 bytes in 1 blocks are possibly lost in loss record 64 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5533A: cv::Jpeg2KDecoder::Jpeg2KDecoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44F0E: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 96 bytes in 1 blocks are possibly lost in loss record 65 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C70FB0: cv::WebPEncoder::WebPEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C444FC: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 100 bytes in 1 blocks are possibly lost in loss record 66 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C56DE0: cv::Jpeg2KEncoder::Jpeg2KEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44FC6: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 104 bytes in 1 blocks are possibly lost in loss record 67 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C53000: cv::HdrEncoder::HdrEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44258: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 104 bytes in 1 blocks are possibly lost in loss record 68 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C61110: cv::TiffEncoder::TiffEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44CE6: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 104 bytes in 1 blocks are possibly lost in loss record 69 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C50930: cv::ExrEncoder::ExrEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C45136: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 108 bytes in 1 blocks are possibly lost in loss record 70 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4FAF0: cv::BmpEncoder::BmpEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44102: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 108 bytes in 1 blocks are possibly lost in loss record 71 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C542B0: cv::JpegEncoder::JpegEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C443AA: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 108 bytes in 1 blocks are possibly lost in loss record 72 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C607F0: cv::SunRasterEncoder::SunRasterEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4465D: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 112 bytes in 1 blocks are possibly lost in loss record 73 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5A640: cv::PAMEncoder::PAMEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44B76: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 116 bytes in 1 blocks are possibly lost in loss record 74 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5EB98: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C447CF: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 116 bytes in 1 blocks are possibly lost in loss record 75 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5EB08: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44949: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 116 bytes in 1 blocks are possibly lost in loss record 76 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5EA88: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44A06: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 116 bytes in 1 blocks are possibly lost in loss record 77 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5BCE0: cv::PngEncoder::PngEncoder() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C44E56: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 120 bytes in 1 blocks are possibly lost in loss record 78 of 105
-==10966==    at 0x483577F: malloc (vg_replace_malloc.c:299)
-==10966==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C5EBF8: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4488C: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x4A9F1A: OcrLite::detect(char const*, char const*, int, int, float, float, float, float, bool, bool) (OcrLite.cpp:74)
-==10966==    by 0x4D8C41: main (main.cpp:134)
-==10966== 
-==10966== 1,680 bytes in 5 blocks are possibly lost in loss record 104 of 105
-==10966==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
-==10966==    by 0x40116E1: allocate_dtv (dl-tls.c:286)
-==10966==    by 0x401204D: _dl_allocate_tls (dl-tls.c:532)
-==10966==    by 0x85E5B95: allocate_stack (allocatestack.c:621)
-==10966==    by 0x85E5B95: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
-==10966==    by 0x574B2D4: cv::WorkerThread::WorkerThread(cv::ThreadPool&, unsigned int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x574CF57: cv::ThreadPool::reconfigure_(unsigned int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x574D6CA: cv::ThreadPool::run(cv::Range const&, cv::ParallelLoopBody const&, double) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x57463CD: cv::parallel_for_(cv::Range const&, cv::ParallelLoopBody const&, double) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5882B79: bool cv::CvtColorIPPLoopCopy<cv::IPPReorderFunctor>(unsigned char const*, unsigned long, int, unsigned char*, unsigned long, int, int, cv::IPPReorderFunctor const&) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x58830BE: cv::hal::cvtBGRtoBGR(unsigned char const*, unsigned long, unsigned char*, unsigned long, int, int, int, int, int, bool) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x5883541: cv::cvtColorBGR2BGR(cv::_InputArray const&, cv::_OutputArray const&, int, bool) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966==    by 0x584E017: cv::cvtColor(cv::_InputArray const&, cv::_OutputArray const&, int, int) (in /media/psf/Home/ChOcrLitProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
-==10966== 
-==10966== LEAK SUMMARY:
-==10966==    definitely lost: 0 bytes in 0 blocks
-==10966==    indirectly lost: 0 bytes in 0 blocks
-==10966==      possibly lost: 3,888 bytes in 27 blocks
-==10966==    still reachable: 85,980 bytes in 103 blocks
-==10966==         suppressed: 0 bytes in 0 blocks
-==10966== Reachable blocks (those to which a pointer was found) are not shown.
-==10966== To see them, rerun with: --leak-check=full --show-leak-kinds=all
-==10966== 
-==10966== For counts of detected and suppressed errors, rerun with: -v
-==10966== ERROR SUMMARY: 23 errors from 23 contexts (suppressed: 0 from 0)
+==4812== Memcheck, a memory error detector
+==4812== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
+==4812== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
+==4812== Command: ./build/OcrLiteOnnx --models models --det dbnet.onnx --cls angle_net.onnx --rec crnn_lite_lstm.onnx --keys keys.txt --image ../images/1.jpg --numThread 1 --padding 50 --maxSideLen 1024 --boxScoreThresh 0.6 --boxThresh 0.3 --unClipRatio 2.0 --doAngle 1 --mostAngle 1
+==4812== Parent PID: 4811
+==4812== 
+==4812== 
+==4812== HEAP SUMMARY:
+==4812==     in use at exit: 17,164 bytes in 131 blocks
+==4812==   total heap usage: 1,856,469 allocs, 1,856,338 frees, 295,468,558 bytes allocated
+==4812== 
+==4812== 80 bytes in 1 blocks are possibly lost in loss record 57 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4FA5F: cv::BmpDecoder::BmpDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4405A: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 80 bytes in 1 blocks are possibly lost in loss record 58 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C54230: cv::JpegDecoder::JpegDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44301: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 84 bytes in 1 blocks are possibly lost in loss record 59 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C52ECB: cv::HdrDecoder::HdrDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C441AF: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 84 bytes in 1 blocks are possibly lost in loss record 60 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C60769: cv::SunRasterDecoder::SunRasterDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C445A5: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 84 bytes in 1 blocks are possibly lost in loss record 61 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C501E5: cv::ExrDecoder::ExrDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4507E: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 88 bytes in 1 blocks are possibly lost in loss record 62 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C52EEF: cv::HdrDecoder::HdrDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C441AF: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 88 bytes in 1 blocks are possibly lost in loss record 63 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5BC30: cv::PngDecoder::PngDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44D9E: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 92 bytes in 1 blocks are possibly lost in loss record 64 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5533A: cv::Jpeg2KDecoder::Jpeg2KDecoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44F0E: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 96 bytes in 1 blocks are possibly lost in loss record 65 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C70FB0: cv::WebPEncoder::WebPEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C444FC: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 100 bytes in 1 blocks are possibly lost in loss record 66 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C56DE0: cv::Jpeg2KEncoder::Jpeg2KEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44FC6: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 104 bytes in 1 blocks are possibly lost in loss record 67 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C53000: cv::HdrEncoder::HdrEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44258: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 104 bytes in 1 blocks are possibly lost in loss record 68 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C61110: cv::TiffEncoder::TiffEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44CE6: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 104 bytes in 1 blocks are possibly lost in loss record 69 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C50930: cv::ExrEncoder::ExrEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C45136: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 108 bytes in 1 blocks are possibly lost in loss record 70 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4FAF0: cv::BmpEncoder::BmpEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44102: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 108 bytes in 1 blocks are possibly lost in loss record 71 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C542B0: cv::JpegEncoder::JpegEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C443AA: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 108 bytes in 1 blocks are possibly lost in loss record 72 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C607F0: cv::SunRasterEncoder::SunRasterEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4465D: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 112 bytes in 1 blocks are possibly lost in loss record 73 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5A640: cv::PAMEncoder::PAMEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44B76: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 116 bytes in 1 blocks are possibly lost in loss record 74 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5EB98: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C447CF: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 116 bytes in 1 blocks are possibly lost in loss record 75 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5EB08: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44949: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 116 bytes in 1 blocks are possibly lost in loss record 76 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5EA88: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44A06: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 116 bytes in 1 blocks are possibly lost in loss record 77 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5BCE0: cv::PngEncoder::PngEncoder() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C44E56: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 120 bytes in 1 blocks are possibly lost in loss record 79 of 105
+==4812==    at 0x483577F: malloc (vg_replace_malloc.c:299)
+==4812==    by 0x5570880: cv::fastMalloc(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x578640C: cv::String::allocate(unsigned long) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C5EBF8: cv::PxMEncoder::PxMEncoder(cv::PxMMode) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4488C: cv::ImageCodecInitializer::ImageCodecInitializer() (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47218: cv::findDecoder(cv::String const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C4736B: cv::imread_(cv::String const&, int, int, cv::Mat*) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5C47A4D: cv::imread(cv::String const&, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x4519AC: OcrLite::detect(char const*, char const*, int, int, float, float, float, bool, bool) (OcrLite.cpp:72)
+==4812==    by 0x4808F4: main (main.cpp:178)
+==4812== 
+==4812== 1,600 bytes in 5 blocks are possibly lost in loss record 105 of 105
+==4812==    at 0x4837B65: calloc (vg_replace_malloc.c:752)
+==4812==    by 0x40116E1: allocate_dtv (dl-tls.c:286)
+==4812==    by 0x401204D: _dl_allocate_tls (dl-tls.c:532)
+==4812==    by 0x85E5B95: allocate_stack (allocatestack.c:621)
+==4812==    by 0x85E5B95: pthread_create@@GLIBC_2.2.5 (pthread_create.c:669)
+==4812==    by 0x574B2D4: cv::WorkerThread::WorkerThread(cv::ThreadPool&, unsigned int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x574CF57: cv::ThreadPool::reconfigure_(unsigned int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x574D6CA: cv::ThreadPool::run(cv::Range const&, cv::ParallelLoopBody const&, double) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x57463CD: cv::parallel_for_(cv::Range const&, cv::ParallelLoopBody const&, double) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5882B79: bool cv::CvtColorIPPLoopCopy<cv::IPPReorderFunctor>(unsigned char const*, unsigned long, int, unsigned char*, unsigned long, int, int, cv::IPPReorderFunctor const&) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x58830BE: cv::hal::cvtBGRtoBGR(unsigned char const*, unsigned long, unsigned char*, unsigned long, int, int, int, int, int, bool) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x5883541: cv::cvtColorBGR2BGR(cv::_InputArray const&, cv::_OutputArray const&, int, bool) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812==    by 0x584E017: cv::cvtColor(cv::_InputArray const&, cv::_OutputArray const&, int, int) (in /media/psf/Home/OCRProjects/OcrLiteOnnx/opencv-shared/linux/lib/libopencv_world.so.3.4.13)
+==4812== 
+==4812== LEAK SUMMARY:
+==4812==    definitely lost: 0 bytes in 0 blocks
+==4812==    indirectly lost: 0 bytes in 0 blocks
+==4812==      possibly lost: 3,808 bytes in 27 blocks
+==4812==    still reachable: 13,356 bytes in 104 blocks
+==4812==         suppressed: 0 bytes in 0 blocks
+==4812== Reachable blocks (those to which a pointer was found) are not shown.
+==4812== To see them, rerun with: --leak-check=full --show-leak-kinds=all
+==4812== 
+==4812== For counts of detected and suppressed errors, rerun with: -v
+==4812== ERROR SUMMARY: 23 errors from 23 contexts (suppressed: 0 from 0)

--- a/cpp_projects/README.md
+++ b/cpp_projects/README.md
@@ -1,6 +1,7 @@
 ## 以下内容仅代表benjaminwan个人观点 仅供参考
 
 #### PC平台onnxruntime vs ncnn对比测试介绍
+
 1. OcrLiteOnnx项目使用onnxruntime框架，OcrLiteNcnn项目使用ncnn框架，用于对比的项目均使用C++编写。
 2. 除了调用推理框架的代码，其它代码尽量保持一致。
 3. 使用chineseocr-lite的onnx分支的模型，ncnn框架使用专用的模型格式，由同一个模型从onnx格式转为ncnn专用格式。
@@ -9,6 +10,7 @@
 6. 对比用的demo下载：[onnx版](https://gitee.com/benjaminwan/ocr-lite-onnx/releases)，[ncnn版](https://gitee.com/benjaminwan/ocr-lite-ncnn/releases)
 
 #### 推理速度对比
+
 1. 在同一台真机上的mac和win双系统中分别测试。
 2. 测试硬件：NUC8I7HVK冥王峡谷(i7-8809G) 32GRAM 2TSSD
 3. 冥王峡谷有2个GPU，GPU0是Radeon RX Vega M(性能相当于GTX1050 Ti，略强于RX560)，GPU1是Intel HD 630
@@ -17,11 +19,32 @@
 6. 测试环境：Windows10 x64，macOS 10.15.7
 7. 20201129更新：除了推理框架使用OpenMP以外，Demo程序的AngleNet和CrnnNet阶段也使用OpenMP来加速计算。实测OpenMP对DbNet阶段没有加速效果，因为DbNet阶段是单任务单线程的。
 8. 20210102更新：ncnn vulkan版，DbNet阶段使用GPU加速，AngleNet和CrnnNet阶段仍然使用CPU+OpenMP多线程计算。
+
 * DbNet阶段特别适合GPU加速，GPU只有compute queue的概念没有线程，低端的GPU只有1个compute queue。
 * 在代码改动小的前提下，实测AngleNet和CrnnNet使用CPU多线程计算更快。
 * 如果重新设计架构，比如CPU x个线程+GPU 1~N个任务，这样并行计算，理论上行得通，但整体改动很大。
 * 因为AngleNet和CrnnNet的数据量小，计算耗时小，即使通过复杂的算法和架构实现提升，也对整体的结果影响小，投入产出比小。
 * 这样的架构好处是：GPU和CPU轮流使用，不容易过热并可以让GPU和CPU都保持在高效的工作频率。代码改动小、程序结构简单。
+
+### 20210129测试结果
+
+| 版本     | Win DbNet  | Win总耗时 | mac DbNet | mac总耗时 |
+| ------- | ------- | ----: | ----: | ----: |
+| onnx(cpu)  | 153.18ms | 216.28ms | 130.38ms | 168.58ms |
+| ncnn(cpu)  | 445.01ms | 493.07ms | 223.18ms | 248.06ms |
+| ncnn(gpu0) | 78.1ms  | 123.84ms | 35.48ms  | 60.12ms  |
+| ncnn(gpu1) | 221.09ms | 274.91ms |  |  |
+
+| 版本     | Win DbNet  | Win总耗时 | mac DbNet | mac总耗时 |
+| ------- | ------- | ----: | ----: | ----: |
+| onnx(cpu)  | 2166.02ms | 5369.50ms | 1982.50ms | 3760.81ms |
+| ncnn(cpu)  | 8360.09ms | 12619.38ms | 4179.19ms | 6567.93ms |
+| ncnn(gpu0) | 824.08ms  | 5007.34ms | 601.29ms  | 929.20ms  |
+| ncnn(gpu1) | 4197.62ms | 4984.89ms |  |  |
+
+--------
+
+### 20210102测试结果
 
 | 版本     | Win DbNet  | Win总耗时 | mac DbNet | mac总耗时 |
 | ------- | ------- | ----: | ----: | ----: |
@@ -38,14 +61,19 @@
 | ncnn(gpu1) | 4155.91ms | 4823.95ms | 1757.84ms  | 2046.62ms |
 
 #### 推理速度对比总结：
+
 1. 仅使用CPU计算时，在mac平台上onnxruntime是ncnn速度的1.5~1.7倍，在win平台则是约2倍，结论是cpu计算方面onnxruntime快很多。
 2. 使用GPU0加速时，使用AMD三百元级别的低端显卡(性能大概略强于RX560)，DbNet阶段加速约5~10倍。
 3. 使用独立显卡GPU0加速时，图片越大，则加速效果越惊人，但奇怪的是，windows下，总耗时数据提升不够大，我个人的猜测是windows下的vulkan仍不够完善，可能从GPU计算完成取出的大量数据送CPU计算的过程造成了延迟，在mac下则表现正常。
 4. 使用核芯显卡GPU1加速时，也能获得不错的加速效果，至少也比ncnn(cpu)快了一倍，并且在windows下，总耗时也很正常，在大图时，竟然夺得了测试成绩第一，可能是核芯显卡与CPU集成在一起的，所以数据传输延迟很低。
-5. 建议：如果没有任何GPU，且CPU的核心数量很多，则使用onnx版最佳。如果有独立显卡且支持vulkan，则使用ncnn vulkan是最好的选择。如有没有独立显卡但CPU带intel核显，则不妨试试ncnn vulkan，性能提升相当于白捡。
+5. 建议：如果没有任何GPU，且CPU的核心数量很多，则使用onnx版最佳。如果有独立显卡且支持vulkan，则使用ncnn vulkan是最好的选择。如有没有独立显卡但CPU带intel核显，则不妨试试ncnn
+   vulkan，性能提升相当于白捡。
+6. 20210129更新：20210129的测试结果中的mac gpu1发生段错误，结果暂缺，问题原因待排查。
 
 #### 其它
+
 对于老平台的支持问题(主要指windows平台)：
+
 * opencv通过自行编译，最老可以支持xp。
 * ncnn(cpu)通过自行编译，最老也能支持xp。
 * onnxruntime只能支持windows7~10。


### PR DESCRIPTION
## C++项目升级1.5.1
* ncnn版适配ncnn v20210124，crnn改用lstm
* onnx版改用新的getInputName和getOutputName方法，修复win7崩溃
* 编译脚本修改
* 更新对比结果readme