### PR TITLE
修复c层库的导出符号导致的jni和exec编译错误

### DIFF
--- a/cpp_projects/OcrLiteNcnn/CMakeLists.txt
+++ b/cpp_projects/OcrLiteNcnn/CMakeLists.txt
@@ -114,6 +114,7 @@ elseif(OCR_CLIB) # C LIB
     target_link_libraries(OcrLiteNcnn ncnn ${OpenCV_LIBS} ${OpenMP_CXX_LIB_NAMES})
 else ()
     add_executable(OcrLiteNcnn ${OCR_COMPILE_CODE})
+    target_compile_definitions(OcrLiteNcnn PRIVATE __EXEC__)
     target_link_libraries(OcrLiteNcnn ncnn ${OpenCV_LIBS} ${OpenMP_CXX_LIB_NAMES})
 endif ()
 
@@ -136,6 +137,7 @@ if (OCR_BENCHMARK AND NOT OCR_LIB AND NOT OCR_CLIB)
             src/OcrLite.cpp
             src/OcrUtils.cpp)
     target_link_libraries(benchmark ncnn ${OpenCV_LIBS} ${OpenMP_CXX_LIB_NAMES})
+    target_compile_definitions(benchmark PRIVATE __EXEC__)
     if (OCR_OPENMP)
         target_compile_definitions(benchmark PRIVATE __OPENMP__)
     endif ()

--- a/cpp_projects/OcrLiteNcnn/include/OcrLitePort.h
+++ b/cpp_projects/OcrLiteNcnn/include/OcrLitePort.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#pragma once
+#if !defined(__JNI__) && !defined(__EXEC__)
 
 // The way how the function is called
 #if !defined(OCRLITE_CALL)
@@ -9,7 +9,7 @@
 #else
 #define OCRLITE_CALL
 #endif /* _WIN32 */
-#endif /* ISSCALL */
+#endif /* OCRLITE_CALL */
 
 #if defined _WIN32 || defined __CYGWIN__
 #define OCRLITE_EXPORT __declspec(dllexport)
@@ -35,3 +35,11 @@
 #define OCR_API OCRLITE_PORT OCRLITE_CALL
 
 #define OCR_LOCAL OCRLITE_LOCAL OCRLITE_CALL
+
+#else // __JNI__ || __EXEC__
+
+#define OCRLITE_PORT
+#define OCR_API
+#define OCR_LOCAL
+
+#endif // __JNI__ || __EXEC__

--- a/cpp_projects/OcrLiteOnnx/CMakeLists.txt
+++ b/cpp_projects/OcrLiteOnnx/CMakeLists.txt
@@ -115,6 +115,7 @@ elseif(OCR_CLIB) # C LIB
     target_link_libraries(OcrLiteOnnx ${OnnxRuntime_LIBS} ${OpenCV_LIBS} ${OpenMP_CXX_LIB_NAMES})
 else ()
     add_executable(OcrLiteOnnx ${OCR_COMPILE_CODE})
+    target_compile_definitions(OcrLiteOnnx PRIVATE __EXEC__)
     target_link_libraries(OcrLiteOnnx ${OnnxRuntime_LIBS} ${OpenCV_LIBS} ${OpenMP_CXX_LIB_NAMES})
 endif ()
 
@@ -133,6 +134,7 @@ if (OCR_BENCHMARK AND NOT OCR_LIB AND NOT OCR_CLIB)
             src/OcrLite.cpp
             src/OcrUtils.cpp)
     target_link_libraries(benchmark ${OnnxRuntime_LIBS} ${OpenCV_LIBS} ${OpenMP_CXX_LIB_NAMES})
+    target_compile_definitions(benchmark PRIVATE __EXEC__)
     if (OCR_OPENMP)
         target_compile_definitions(benchmark PRIVATE __OPENMP__)
     endif ()

--- a/cpp_projects/OcrLiteOnnx/include/OcrLitePort.h
+++ b/cpp_projects/OcrLiteOnnx/include/OcrLitePort.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#pragma once
+#if !defined(__JNI__) && !defined(__EXEC__)
 
 // The way how the function is called
 #if !defined(OCRLITE_CALL)
@@ -9,7 +9,7 @@
 #else
 #define OCRLITE_CALL
 #endif /* _WIN32 */
-#endif /* ISSCALL */
+#endif /* OCRLITE_CALL */
 
 #if defined _WIN32 || defined __CYGWIN__
 #define OCRLITE_EXPORT __declspec(dllexport)
@@ -35,3 +35,11 @@
 #define OCR_API OCRLITE_PORT OCRLITE_CALL
 
 #define OCR_LOCAL OCRLITE_LOCAL OCRLITE_CALL
+
+#else // __JNI__ || __EXEC__
+
+#define OCRLITE_PORT
+#define OCR_API
+#define OCR_LOCAL
+
+#endif // __JNI__ || __EXEC__


### PR DESCRIPTION
不好意思，昨天没怎么测别的选项_(:з」∠)_
今天发现不对赶紧修了下